### PR TITLE
fix redirect loop

### DIFF
--- a/components/ILIAS/LTIProvider/classes/class.ilLTIViewGUI.php
+++ b/components/ILIAS/LTIProvider/classes/class.ilLTIViewGUI.php
@@ -204,6 +204,11 @@ class ilLTIViewGUI
                 if (ilSession::has('referer_ref_id')) {
                     $this->effectiveRefId = ilSession::get('referer_ref_id');
                 }
+                // fix redirect loop
+                if(ilSession::has('lti_context_ids') && isset(ilSession::get('lti_context_ids')[0]))  {
+                    $context_id = (int) ilSession::get('lti_context_ids')[0];
+                    $this->effectiveRefId = $context_id;
+                }    
             }
 
             $referer = (int) $this->effectiveRefId;


### PR DESCRIPTION
Fixes a redirect loop, that occurs when falling back to refId 1 when discerning the correct contextID for LTI content.